### PR TITLE
Add platformio configuration

### DIFF
--- a/lmic_config.h
+++ b/lmic_config.h
@@ -1,0 +1,6 @@
+#define CFG_eu868 1
+#define CFG_sx1276_radio 1
+
+#define LMIC_DEBUG_LEVEL 2
+//#define LMIC_USE_INTERRUPTS
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,28 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = espressif32
+board = heltec_wifi_lora_32
+build_flags = -DARDUINO_LMIC_PROJECT_CONFIG_H=../../../lmic_config.h
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+lib_deps = 
+    Adafruit Unified Sensor
+    Adafruit BME280 Library
+    Adafruit BME680 Library    
+    Adafruit GFX Library
+    Adafruit SSD1306
+    MCCI LoRaWAN LMIC library
+    


### PR DESCRIPTION
I've created a platformio configuration for this project. This allows you to build the software from the command line instead of the Arduino IDE, with all settings (which target to use, target options, which libraries to use, their versions, etc.) defined in the platformio.ini text file. This makes it possible to do a reproducible build with the tool chains and libraries automatically downloaded. You can even build the Arduino software on a platform like Travis-ci.

Maybe you find this useful.

You can install platformio as follows (under Debian Linux):
  sudo apt-get install python-pip
  sudo pip install platformio
  pio update

Then you can build and upload the application using
  pio run -t upload

And monitor the serial port using
  pio device monitor